### PR TITLE
Fix packages/common imports

### DIFF
--- a/config/api.Dockerfile
+++ b/config/api.Dockerfile
@@ -14,10 +14,8 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 
 # Copy all workspace members
-COPY packages/db ./packages/db
-COPY packages/vod ./packages/vod
+COPY packages/ ./packages/
 COPY services/forge-queue ./services/forge-queue
-COPY packages/queue ./packages/queue
 COPY services/silo-api ./services/silo-api
 
 # Build the project for release

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -14,9 +14,7 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 
 # Copy all workspace members
-COPY packages/db ./packages/db
-COPY packages/vod ./packages/vod
-COPY packages/queue ./packages/queue
+COPY packages/ ./packages/
 COPY services/forge-queue ./services/forge-queue
 COPY services/silo-api ./services/silo-api
 


### PR DESCRIPTION
The Dockerfiles were not importing the common package correctly. Although, this may be representative of a CI issue where we should probably be building the docker image instead of the binary directly