### PR TITLE
Fix FFMPEG missing from Dockerfile

### DIFF
--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -26,12 +26,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp /app/target/release/forge /usr/local/bin/forge
 
 # Runtime stage
-FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+FROM --platform=$TARGETPLATFORM jrottenberg/ffmpeg:ffmpeg-7.1-alpine320
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    ffmpeg \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y \
 # Copy the binary from builder
 COPY --from=builder /usr/local/bin/forge /usr/local/bin/forge
 # Copy ffmpeg
-COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
+COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /usr/local/bin/ffmpeg /usr/bin/ffmpeg
 
 # Expose the health check server
 EXPOSE 8080

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p forge && \
     cp /app/target/release/forge /usr/local/bin/forge
 
-COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /usr/local/bin/ffmpeg /usr/bin/ffmpeg
+COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /opt/ffmpeg /usr/local/ffmpeg
 
 # Runtime stage
 FROM --platform=$TARGETPLATFORM debian:bullseye-slim

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -29,9 +29,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM jrottenberg/ffmpeg:7.1-ubuntu2404-edge
 # Install runtime dependencies
-RUN apt-get update && apt-get install -y \
-    mlocate \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y which
+
 
 ENTRYPOINT ["which"]
 CMD ["ffmpeg"]

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get update && apt-get install -y \
 COPY --from=builder /usr/local/bin/forge /usr/local/bin/forge
 # Copy ffmpeg
 COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /usr/local/bin/ffmpeg /usr/bin/ffmpeg
+# Copy ffprobe
+COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /usr/local/bin/ffprobe /usr/bin/ffprobe
 
 # Expose the health check server
 EXPOSE 8080

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp /app/target/release/forge /usr/local/bin/forge
 
 # Runtime stage
-FROM --platform=$TARGETPLATFORM jrottenberg/ffmpeg:ffmpeg-7.1-alpine320
+FROM jrottenberg/ffmpeg:7.1-alpine320
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -28,8 +28,13 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /opt/ffmpeg /usr/local/ffmpeg
 
 FROM jrottenberg/ffmpeg:7.1-ubuntu2404-edge
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    mlocate \
+    && rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT [ "which ffmpeg" ]
+ENTRYPOINT ["which"]
+CMD ["ffmpeg"]
 # Runtime stage
 # FROM --platform=$TARGETPLATFORM debian:bullseye-slim
 

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 
 # Runtime stage
-FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+FROM jrottenberg/ffmpeg:7.1-ubuntu2404-edge
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
@@ -37,10 +37,6 @@ RUN apt-get update && apt-get install -y \
 
 # Copy the binary from builder
 COPY --from=builder /usr/local/bin/forge /usr/local/bin/forge
-# Copy ffmpeg
-COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /usr/local/bin/ffmpeg /usr/bin/ffmpeg
-# Copy ffprobe
-COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /usr/local/bin/ffprobe /usr/bin/ffprobe
 
 # Expose the health check server
 EXPOSE 8080

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp /app/target/release/forge /usr/local/bin/forge
 
 # Runtime stage
-FROM jrottenberg/ffmpeg:7.1-alpine320
+FROM jrottenberg/ffmpeg:7.1-ubuntu2404-edge
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -25,22 +25,25 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p forge && \
     cp /app/target/release/forge /usr/local/bin/forge
 
-COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /opt/ffmpeg /usr/local/ffmpeg
+# COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /opt/ffmpeg /usr/local/ffmpeg
 
+FROM jrottenberg/ffmpeg:7.1-ubuntu2404-edge
+
+ENTRYPOINT [ "where ffmpeg" ]
 # Runtime stage
-FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+# FROM --platform=$TARGETPLATFORM debian:bullseye-slim
 
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    libpq5 \
-    && rm -rf /var/lib/apt/lists/*
+# # Install runtime dependencies
+# RUN apt-get update && apt-get install -y \
+#     ca-certificates \
+#     libpq5 \
+#     && rm -rf /var/lib/apt/lists/*
 
-# Copy the binary from builder
-COPY --from=builder /usr/local/bin/forge /usr/local/bin/forge
+# # Copy the binary from builder
+# COPY --from=builder /usr/local/bin/forge /usr/local/bin/forge
 
-# Expose the health check server
-EXPOSE 8080
+# # Expose the health check server
+# EXPOSE 8080
 
-# Set the entrypoint
-ENTRYPOINT ["/usr/local/bin/forge"]
+# # Set the entrypoint
+# ENTRYPOINT ["/usr/local/bin/forge"]

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -25,29 +25,23 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p forge && \
     cp /app/target/release/forge /usr/local/bin/forge
 
-# COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /opt/ffmpeg /usr/local/ffmpeg
 
-FROM jrottenberg/ffmpeg:7.1-ubuntu2404-edge
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y which
-
-
-ENTRYPOINT ["which"]
-CMD ["ffmpeg"]
 # Runtime stage
-# FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+FROM --platform=$TARGETPLATFORM debian:bullseye-slim
 
-# # Install runtime dependencies
-# RUN apt-get update && apt-get install -y \
-#     ca-certificates \
-#     libpq5 \
-#     && rm -rf /var/lib/apt/lists/*
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libpq5 \
+    && rm -rf /var/lib/apt/lists/*
 
-# # Copy the binary from builder
-# COPY --from=builder /usr/local/bin/forge /usr/local/bin/forge
+# Copy the binary from builder
+COPY --from=builder /usr/local/bin/forge /usr/local/bin/forge
+# Copy ffmpeg
+COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
 
-# # Expose the health check server
-# EXPOSE 8080
+# Expose the health check server
+EXPOSE 8080
 
-# # Set the entrypoint
-# ENTRYPOINT ["/usr/local/bin/forge"]
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/forge"]

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM jrottenberg/ffmpeg:7.1-ubuntu2404-edge
 
-ENTRYPOINT [ "where ffmpeg" ]
+ENTRYPOINT [ "which ffmpeg" ]
 # Runtime stage
 # FROM --platform=$TARGETPLATFORM debian:bullseye-slim
 

--- a/config/queue.Dockerfile
+++ b/config/queue.Dockerfile
@@ -25,8 +25,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p forge && \
     cp /app/target/release/forge /usr/local/bin/forge
 
+COPY --from=jrottenberg/ffmpeg:7.1-ubuntu2404-edge /usr/local/bin/ffmpeg /usr/bin/ffmpeg
+
 # Runtime stage
-FROM jrottenberg/ffmpeg:7.1-ubuntu2404-edge
+FROM --platform=$TARGETPLATFORM debian:bullseye-slim
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/k8s/base/queue/configmap.yaml
+++ b/k8s/base/queue/configmap.yaml
@@ -6,3 +6,4 @@ data:
   RUST_LOG: "api=debug,db=debug,queue=debug,vod=debug,tower_http=debug,axum::rejection=trace"
   STORAGE: "videos/staging"
   UPLOAD_BUCKET: "farmhand"
+  FFMPEG_LOCATION: "/usr/local/bin/ffmpeg"

--- a/k8s/base/queue/configmap.yaml
+++ b/k8s/base/queue/configmap.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: farmhand-queue-config
 data:
-  RUST_LOG: "api=debug,db=debug,queue=debug,tower_http=debug,axum::rejection=trace"
+  RUST_LOG: "api=debug,db=debug,queue=debug,vod=debug,tower_http=debug,axum::rejection=trace"
   STORAGE: "videos/staging"
   UPLOAD_BUCKET: "farmhand"

--- a/packages/vod/src/stream.rs
+++ b/packages/vod/src/stream.rs
@@ -84,6 +84,7 @@ impl Quality {
 
 impl HLSConverter {
     fn get_video_dimensions(&self, input_path: &Path) -> Result<(u32, u32)> {
+        debug!("Getting dimensions for {:?}", input_path);
         let output = Command::new(&self.ffmpeg_path)
             .arg("-i")
             .arg(input_path)


### PR DESCRIPTION
The queue's Dockerfile wasn't properly configured with FFMPEG, causing the processing jobs to fail. This adds ffmpeg correctly into the image.