### PR TITLE
Add ability to save user settings

### DIFF
--- a/crates/common/migrations/20250212051114_add_user_settings.down.sql
+++ b/crates/common/migrations/20250212051114_add_user_settings.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_settings;

--- a/crates/common/migrations/20250212051114_add_user_settings.up.sql
+++ b/crates/common/migrations/20250212051114_add_user_settings.up.sql
@@ -1,0 +1,37 @@
+-- Create user_settings table
+CREATE TABLE user_settings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    stream_status_enabled TIMESTAMPTZ DEFAULT NULL,
+    chat_messages_enabled TIMESTAMPTZ DEFAULT NULL,
+    channel_points_enabled TIMESTAMPTZ DEFAULT NULL,
+    follows_subs_enabled TIMESTAMPTZ DEFAULT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id)
+);
+
+-- Create index for faster lookups
+CREATE INDEX idx_user_settings_user_id ON user_settings(user_id);
+
+-- Create update trigger for updated_at
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_user_settings_updated_at
+    BEFORE UPDATE ON user_settings
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Insert default settings for existing users
+INSERT INTO user_settings (user_id)
+SELECT id FROM users
+ON CONFLICT DO NOTHING;
+
+-- Add a comment to the table
+COMMENT ON TABLE user_settings IS 'Stores user-specific settings for Twitch integration features';

--- a/crates/common/src/db/users.rs
+++ b/crates/common/src/db/users.rs
@@ -2,6 +2,7 @@ use argon2::{
     password_hash::{rand_core::OsRng, PasswordHasher, SaltString},
     Argon2, PasswordVerifier,
 };
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{types::Uuid, PgPool};
 
@@ -15,6 +16,40 @@ pub struct User {
     pub role: UserRole,
     pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
+    #[sqlx(skip)]
+    pub settings: Option<UserSettings>,
+}
+
+#[derive(sqlx::FromRow, Serialize, Deserialize, Clone)]
+pub struct UserSettings {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub stream_status_enabled: Option<DateTime<Utc>>,
+    pub chat_messages_enabled: Option<DateTime<Utc>>,
+    pub channel_points_enabled: Option<DateTime<Utc>>,
+    pub follows_subs_enabled: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(sqlx::FromRow, Serialize, Deserialize, Clone)]
+pub struct UserWithSettings {
+    // User fields
+    pub id: Uuid,
+    pub email: String,
+    pub username: String,
+    pub password_hash: String,
+    pub role: UserRole,
+    pub created_at: chrono::NaiveDateTime,
+    pub updated_at: chrono::NaiveDateTime,
+    // Settings fields
+    pub settings_id: Uuid,
+    pub stream_status_enabled: Option<DateTime<Utc>>,
+    pub chat_messages_enabled: Option<DateTime<Utc>>,
+    pub channel_points_enabled: Option<DateTime<Utc>>,
+    pub follows_subs_enabled: Option<DateTime<Utc>>,
+    pub settings_created_at: DateTime<Utc>,
+    pub settings_updated_at: DateTime<Utc>,
 }
 
 #[derive(sqlx::Type, Serialize, Deserialize, Clone)]
@@ -43,6 +78,7 @@ impl User {
             role: UserRole::Viewer,
             created_at: chrono::Utc::now().naive_utc(),
             updated_at: chrono::Utc::now().naive_utc(),
+            settings: None,
         }
     }
     /// Gets a user from the databased based on Username
@@ -54,10 +90,45 @@ impl User {
     }
     /// Gets a user from the database based on ID
     pub async fn by_id(id: Uuid, pool: &PgPool) -> Result<Self, sqlx::Error> {
-        sqlx::query_as::<_, User>("SELECT * FROM users WHERE id = $1")
-            .bind(id)
-            .fetch_one(pool)
-            .await
+        let row = sqlx::query_as::<_, UserWithSettings>(
+            r#"
+                SELECT
+                    u.*,
+                    s.id as settings_id,
+                    s.stream_status_enabled,
+                    s.chat_messages_enabled,
+                    s.channel_points_enabled,
+                    s.follows_subs_enabled,
+                    s.created_at as settings_created_at,
+                    s.updated_at as settings_updated_at
+                FROM users u
+                LEFT JOIN user_settings s ON s.user_id = u.id
+                WHERE u.id = $1
+                "#,
+        )
+        .bind(id)
+        .fetch_one(pool)
+        .await?;
+
+        Ok(User {
+            id: row.id,
+            email: row.email,
+            username: row.username,
+            password_hash: row.password_hash,
+            role: row.role,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            settings: Some(UserSettings {
+                id: row.settings_id,
+                user_id: row.id,
+                stream_status_enabled: row.stream_status_enabled,
+                chat_messages_enabled: row.chat_messages_enabled,
+                channel_points_enabled: row.channel_points_enabled,
+                follows_subs_enabled: row.follows_subs_enabled,
+                created_at: row.settings_created_at,
+                updated_at: row.settings_updated_at,
+            }),
+        })
     }
     /// Gets a user from the databased based on Email
     pub async fn by_email(email: String, pool: &PgPool) -> Result<Self, sqlx::Error> {
@@ -68,9 +139,82 @@ impl User {
     }
     /// Gets all users from the database
     pub async fn all(pool: &PgPool) -> Result<Vec<Self>, sqlx::Error> {
-        sqlx::query_as::<_, User>("SELECT * FROM users")
-            .fetch_all(pool)
-            .await
+        let rows = sqlx::query_as::<_, UserWithSettings>(
+            r#"
+                SELECT
+                    u.*,
+                    s.id as settings_id,
+                    s.stream_status_enabled,
+                    s.chat_messages_enabled,
+                    s.channel_points_enabled,
+                    s.follows_subs_enabled,
+                    s.created_at as settings_created_at,
+                    s.updated_at as settings_updated_at
+                FROM users u
+                LEFT JOIN user_settings s ON s.user_id = u.id
+                "#,
+        )
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| User {
+                id: row.id,
+                email: row.email,
+                username: row.username,
+                password_hash: row.password_hash,
+                role: row.role,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                settings: Some(UserSettings {
+                    id: row.settings_id,
+                    user_id: row.id,
+                    stream_status_enabled: row.stream_status_enabled,
+                    chat_messages_enabled: row.chat_messages_enabled,
+                    channel_points_enabled: row.channel_points_enabled,
+                    follows_subs_enabled: row.follows_subs_enabled,
+                    created_at: row.settings_created_at,
+                    updated_at: row.settings_updated_at,
+                }),
+            })
+            .collect())
+    }
+    /// Updates the user's settings
+    pub async fn update_settings(
+        &mut self,
+        stream_status: bool,
+        chat_messages: bool,
+        channel_points: bool,
+        follows_subs: bool,
+        pool: &PgPool,
+    ) -> Result<&UserSettings, sqlx::Error> {
+        let now = Utc::now();
+
+        let settings = sqlx::query_as::<_, UserSettings>(
+            r#"
+                UPDATE user_settings
+                SET
+                    stream_status_enabled = CASE WHEN $1 THEN $5 ELSE NULL END,
+                    chat_messages_enabled = CASE WHEN $2 THEN $5 ELSE NULL END,
+                    channel_points_enabled = CASE WHEN $3 THEN $5 ELSE NULL END,
+                    follows_subs_enabled = CASE WHEN $4 THEN $5 ELSE NULL END,
+                    updated_at = $5
+                WHERE user_id = $6
+                RETURNING *
+                "#,
+        )
+        .bind(stream_status)
+        .bind(chat_messages)
+        .bind(channel_points)
+        .bind(follows_subs)
+        .bind(now)
+        .bind(self.id)
+        .fetch_one(pool)
+        .await?;
+
+        self.settings = Some(settings);
+        Ok(self.settings.as_ref().unwrap())
     }
     /// Checks that the raw password matches the expected-to-be-hashed password
     pub fn check_password(&self, raw_password: String) -> Result<(), UserError> {

--- a/services/barn-ui/.prettierrc
+++ b/services/barn-ui/.prettierrc
@@ -3,10 +3,7 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"plugins": [
-		"prettier-plugin-svelte",
-		"prettier-plugin-tailwindcss"
-	],
+	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
 	"overrides": [
 		{
 			"files": "*.svelte",

--- a/services/barn-ui/postcss.config.js
+++ b/services/barn-ui/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {}
-  }
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {}
+	}
 };

--- a/services/barn-ui/src/lib/components/Header.svelte
+++ b/services/barn-ui/src/lib/components/Header.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
 	import Logo from './Logo.svelte';
-	let { actions, width = 'w-full max-w-screen-xl', class: className } = $props();
+	let { actions, width = 'w-full max-w-screen-xl', class: className, headerLink = '/' } = $props();
 </script>
 
 <header class="z-50 flex w-full items-center justify-center text-black dark:text-white {className}">
 	<nav class="flex items-center justify-between py-4 text-sm {width}">
 		<div class="justify-even-10 flex flex-nowrap items-center space-x-10">
-			<a href="/" class="flex flex-nowrap items-center">
+			<a href={headerLink} class="flex flex-nowrap items-center">
 				<Logo size={50} />
 				<span class="font-semibold">FARMHAND</span>
 			</a>
-			<a href="/videos">Videos</a>
 		</div>
 		<aside class="flex items-center space-x-2">
 			{@render actions()}

--- a/services/barn-ui/src/lib/components/Input.svelte
+++ b/services/barn-ui/src/lib/components/Input.svelte
@@ -13,6 +13,6 @@
 		{type}
 		{value}
 		{placeholder}
-		class="input rounded border-2 text-black placeholder-primary-200 dark:border-primary-950 dark:bg-primary-800 dark:text-primary-50"
+		class="dark:border-primary-950 input rounded border-2 text-black placeholder-primary-200 dark:bg-primary-800 dark:text-primary-50"
 	/>
 </label>

--- a/services/barn-ui/src/lib/components/MyAccount.svelte
+++ b/services/barn-ui/src/lib/components/MyAccount.svelte
@@ -15,11 +15,6 @@
 			copy: 'My Account',
 			icon: MyAccount,
 			url: '/me'
-		},
-		{
-			copy: 'My Videos',
-			icon: Video,
-			url: '/me/videos'
 		}
 	];
 </script>

--- a/services/barn-ui/src/lib/components/VideoPlayer.svelte
+++ b/services/barn-ui/src/lib/components/VideoPlayer.svelte
@@ -43,7 +43,7 @@
 		{:else}
 			<video
 				bind:this={videoElement}
-				class="bg-surface-100 h-full w-full border-8 border-secondary-300 shadow-xl dark:border-primary-900 dark:bg-primary-900"
+				class="h-full w-full border-8 border-secondary-300 bg-surface-100 shadow-xl dark:border-primary-900 dark:bg-primary-900"
 				controls
 				playsinline
 				autoplay

--- a/services/barn-ui/src/routes/(guest)/+layout.svelte
+++ b/services/barn-ui/src/routes/(guest)/+layout.svelte
@@ -14,11 +14,9 @@
 	<Header class="mx-auto w-full max-w-screen-xl">
 		{#snippet actions()}
 			{#if data.user}
-				<Button variant="secondary" href="/upload">Upload</Button>
 				<MyAccount user={data.user} />
 			{:else}
 				<Button href="/login">Log in</Button>
-				<Button href="/register">Register</Button>
 			{/if}
 			<ThemeToggler />
 		{/snippet}

--- a/services/barn-ui/src/routes/(user)/+layout@.svelte
+++ b/services/barn-ui/src/routes/(user)/+layout@.svelte
@@ -8,16 +8,25 @@
 	import Button from '$lib/components/Button.svelte';
 
 	let { children, data }: { children: Snippet; data: LayoutServerData } = $props();
+	const sidebarLinks = [
+		{
+			link: '/dashboard/streams',
+			label: 'Streams'
+		}
+	];
 </script>
 
 <main class="grid min-h-screen grid-cols-12 grid-rows-main divide-x divide-y">
 	<Header
 		width="w-full max-w-none"
 		class="dark:bg-primary-950/30 col-span-12 row-start-1 border-primary-200/20 bg-black/40 backdrop-blur-sm dark:border-primary-800/40"
+		headerLink="/dashboard"
 	>
 		{#snippet actions()}
-			<nav class="mr-4 flex justify-evenly space-x-4">
-				<Button variant="secondary" href="/upload">Upload</Button>
+			<nav class="mr-4 flex items-center justify-evenly space-x-4">
+				<a href="/dashboard">
+					<span class="font-semibold">Dashboard</span>
+				</a>
 				<MyAccount user={data.user} />
 				<ThemeToggler />
 			</nav>
@@ -28,12 +37,11 @@
 	>
 		<nav>
 			<ul>
-				<li>
-					<a href="/me/videos">My Videos</a>
-				</li>
-				<li>
-					<a href="/upload">Upload</a>
-				</li>
+				{#each sidebarLinks as link}
+					<li class="font-semibold uppercase">
+						<a href={link.link}>{link.label}</a>
+					</li>
+				{/each}
 			</ul>
 		</nav>
 	</aside>

--- a/services/barn-ui/src/routes/(user)/dashboard/+page.svelte
+++ b/services/barn-ui/src/routes/(user)/dashboard/+page.svelte
@@ -1,0 +1,1 @@
+Dashboard hey

--- a/services/barn-ui/src/routes/(user)/dashboard/streams/+page.svelte
+++ b/services/barn-ui/src/routes/(user)/dashboard/streams/+page.svelte
@@ -1,0 +1,1 @@
+streams hey

--- a/services/barn-ui/src/routes/(user)/me/+page.server.ts
+++ b/services/barn-ui/src/routes/(user)/me/+page.server.ts
@@ -1,0 +1,69 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { env } from '$env/dynamic/private';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	if (!locals.user) {
+		throw redirect(303, '/login');
+	}
+
+	return {
+		user: locals.user
+	};
+};
+
+export const actions = {
+	updateTwitchSettings: async ({ request, fetch, locals, cookies }) => {
+		if (!locals.user) {
+			throw redirect(303, '/login');
+		}
+
+		const formData = await request.formData();
+		const settings = {
+			username: locals.user.username,
+			settings: {
+				stream_status_enabled: formData.get('streamStatus') === 'on',
+				chat_messages_enabled: formData.get('chatMessages') === 'on',
+				channel_points_enabled: formData.get('channelPoints') === 'on',
+				follows_subs_enabled: formData.get('followsSubs') === 'on'
+			}
+		};
+
+		try {
+			const token = cookies.get('jwt');
+			if (!token) {
+				return fail(401, {
+					success: false,
+					message: 'Unauthorized'
+				});
+			}
+			const response = await fetch(`${env.API_URL}/user/me`, {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${token}` // Assuming token is stored in locals
+				},
+				body: JSON.stringify(settings)
+			});
+
+			if (!response.ok) {
+				return fail(response.status, {
+					success: false,
+					message: 'Failed to update settings'
+				});
+			}
+
+			const updatedUser = await response.json();
+			return {
+				success: true,
+				user: updatedUser
+			};
+		} catch (error) {
+			console.error('Error updating settings:', error);
+			return fail(500, {
+				success: false,
+				message: 'Failed to update settings'
+			});
+		}
+	}
+} satisfies Actions;

--- a/services/barn-ui/src/routes/(user)/me/+page.svelte
+++ b/services/barn-ui/src/routes/(user)/me/+page.svelte
@@ -17,7 +17,9 @@
 		>
 			<span class="text-xl">Welcome</span> <span class="uppercase">{user.username}</span>
 		</h1>
-		<p>Manage your account here</p>
+		<p class="text-lg font-semibold text-primary-700 dark:text-primary-100">
+			Manage your account here
+		</p>
 	</aside>
 	<Card>
 		<div slot="header">
@@ -39,5 +41,52 @@
 				>
 			</div>
 		</div>
+	</Card>
+	<Card>
+		<div slot="header">
+			<h3 class="font-serif text-lg text-primary-700 dark:text-primary-100">Twitch Integration</h3>
+			<p class="text-sm text-primary-400 dark:text-primary-200">
+				Configure your Twitch API connections
+			</p>
+		</div>
+		<form slot="content" class="flex flex-col space-y-4">
+			<div class="flex items-center justify-between">
+				<div>
+					<label for="toggleStream" class="font-semibold text-primary-700 dark:text-white">
+						Stream Status
+						<p class="text-sm text-primary-400">Track when stream starts and stops</p>
+					</label>
+				</div>
+				<input type="checkbox" class="checkbox checked:border-primary-500" name="streamStatus" />
+			</div>
+			<div class="flex items-center justify-between">
+				<div>
+					<label for="toggleChat" class="font-semibold text-primary-700 dark:text-white">
+						Chat Messages
+						<p class="text-sm text-primary-400">Access Twitch chat messages</p>
+					</label>
+				</div>
+				<input type="checkbox" class="checkbox checked:border-primary-500" name="chatMessages" />
+			</div>
+			<div class="flex items-center justify-between">
+				<div>
+					<label for="togglePoints" class="font-semibold text-primary-700 dark:text-white">
+						Channel Points
+						<p class="text-sm text-primary-400">Manage channel point rewards</p>
+					</label>
+				</div>
+				<input type="checkbox" class="checkbox checked:border-primary-500" name="channelPoints" />
+			</div>
+			<div class="flex items-center justify-between">
+				<div>
+					<label for="toggleSubs" class="font-semibold text-primary-700 dark:text-white">
+						Follows & Subs
+						<p class="text-sm text-primary-400">Track follower and subscriber events</p>
+					</label>
+				</div>
+				<input type="checkbox" class="checkbox checked:border-primary-500" name="followsSubs" />
+			</div>
+			<button class="variant-filled-primary btn w-full">Save Integration Settings</button>
+		</form>
 	</Card>
 </section>

--- a/services/barn-ui/src/routes/(user)/me/+page.svelte
+++ b/services/barn-ui/src/routes/(user)/me/+page.svelte
@@ -1,13 +1,30 @@
 <script lang="ts">
 	import Card from '$lib/components/Card.svelte';
-	import { page } from '$app/stores';
-	import { redirect } from '@sveltejs/kit';
+	import { enhance } from '$app/forms';
+	import type { PageData, ActionData } from './$types';
+	import type { ActionResult } from '@sveltejs/kit';
 
-	if (!$page.data.user) {
-		redirect(303, '/login');
+	let { data, form } = $props<{ data: PageData; form: ActionData }>();
+
+	let message = $state<string | null>(null);
+	let { user } = data;
+
+	function clearMessage() {
+		message = null;
 	}
 
-	const user = $page.data.user;
+	const submitEnhance = () => {
+		return async ({ result }: { result: ActionResult }) => {
+			if (result.type === 'success') {
+				message = 'Settings saved successfully';
+			} else if (result.type === 'failure') {
+				message = 'Failed to save settings';
+			} else {
+				message = 'An unexpected error occurred';
+			}
+			setTimeout(() => (message = null), 3000);
+		};
+	};
 </script>
 
 <section class="flex flex-col items-center justify-center space-y-10">
@@ -15,12 +32,14 @@
 		<h1
 			class="nowrap flex flex-col text-center font-serif text-2xl text-primary-700 dark:text-primary-500"
 		>
-			<span class="text-xl">Welcome</span> <span class="uppercase">{user.username}</span>
+			<span class="text-xl">Welcome</span>
+			<span class="uppercase">{user.username}</span>
 		</h1>
 		<p class="text-lg font-semibold text-primary-700 dark:text-primary-100">
 			Manage your account here
 		</p>
 	</aside>
+
 	<Card>
 		<div slot="header">
 			<h3 class="font-serif text-lg text-primary-700 dark:text-primary-100">Your Account</h3>
@@ -37,11 +56,13 @@
 				<p class="text-xs text-primary-400 dark:text-white">Role</p>
 				<span
 					class="rounded-full bg-primary-100 font-medium text-primary-800 dark:bg-primary-800 dark:text-primary-100"
-					>{user.role}</span
 				>
+					{user.role}
+				</span>
 			</div>
 		</div>
 	</Card>
+
 	<Card>
 		<div slot="header">
 			<h3 class="font-serif text-lg text-primary-700 dark:text-primary-100">Twitch Integration</h3>
@@ -49,44 +70,90 @@
 				Configure your Twitch API connections
 			</p>
 		</div>
-		<form slot="content" class="flex flex-col space-y-4">
+		<form
+			slot="content"
+			class="flex flex-col space-y-4"
+			method="POST"
+			action="?/updateTwitchSettings"
+			use:enhance={submitEnhance}
+		>
 			<div class="flex items-center justify-between">
 				<div>
-					<label for="toggleStream" class="font-semibold text-primary-700 dark:text-white">
+					<label for="streamStatus" class="font-semibold text-primary-700 dark:text-white">
 						Stream Status
 						<p class="text-sm text-primary-400">Track when stream starts and stops</p>
 					</label>
 				</div>
-				<input type="checkbox" class="checkbox checked:border-primary-500" name="streamStatus" />
+				<input
+					type="checkbox"
+					id="streamStatus"
+					class="checkbox checked:border-primary-500"
+					name="streamStatus"
+					checked={user.settings?.stream_status_enabled !== null}
+				/>
 			</div>
+
 			<div class="flex items-center justify-between">
 				<div>
-					<label for="toggleChat" class="font-semibold text-primary-700 dark:text-white">
+					<label for="chatMessages" class="font-semibold text-primary-700 dark:text-white">
 						Chat Messages
 						<p class="text-sm text-primary-400">Access Twitch chat messages</p>
 					</label>
 				</div>
-				<input type="checkbox" class="checkbox checked:border-primary-500" name="chatMessages" />
+				<input
+					type="checkbox"
+					id="chatMessages"
+					class="checkbox checked:border-primary-500"
+					name="chatMessages"
+					checked={user.settings?.chat_messages_enabled !== null}
+				/>
 			</div>
+
 			<div class="flex items-center justify-between">
 				<div>
-					<label for="togglePoints" class="font-semibold text-primary-700 dark:text-white">
+					<label for="channelPoints" class="font-semibold text-primary-700 dark:text-white">
 						Channel Points
 						<p class="text-sm text-primary-400">Manage channel point rewards</p>
 					</label>
 				</div>
-				<input type="checkbox" class="checkbox checked:border-primary-500" name="channelPoints" />
+				<input
+					type="checkbox"
+					id="channelPoints"
+					class="checkbox checked:border-primary-500"
+					name="channelPoints"
+					checked={user.settings?.channel_points_enabled !== null}
+				/>
 			</div>
+
 			<div class="flex items-center justify-between">
 				<div>
-					<label for="toggleSubs" class="font-semibold text-primary-700 dark:text-white">
+					<label for="followsSubs" class="font-semibold text-primary-700 dark:text-white">
 						Follows & Subs
 						<p class="text-sm text-primary-400">Track follower and subscriber events</p>
 					</label>
 				</div>
-				<input type="checkbox" class="checkbox checked:border-primary-500" name="followsSubs" />
+				<input
+					type="checkbox"
+					id="followsSubs"
+					class="checkbox checked:border-primary-500"
+					name="followsSubs"
+					checked={user.settings?.follows_subs_enabled !== null}
+				/>
 			</div>
-			<button class="variant-filled-primary btn w-full">Save Integration Settings</button>
+
+			{#if message}
+				<p
+					class="text-center text-sm"
+					class:text-green-500={message.includes('success')}
+					class:text-red-500={message.includes('Failed')}
+				>
+					{message}
+				</p>
+			{/if}
+
+			<button class="variant-filled-primary btn w-full" type="submit">
+				Save Integration Settings
+			</button>
 		</form>
 	</Card>
 </section>

--- a/services/silo-api/src/main.rs
+++ b/services/silo-api/src/main.rs
@@ -8,7 +8,7 @@ pub use app_state::AppState;
 use axum::{
     middleware as axum_mw,
     response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{delete, get, post, put},
     Router,
 };
 use config::Config;
@@ -71,6 +71,7 @@ async fn main() {
             "/user",
             Router::new()
                 .route("/me", get(routes::user::get_self))
+                .route("/me", put(routes::user::save_user))
                 .layer(axum_mw::from_fn_with_state(
                     state.clone(),
                     middleware::auth::auth_middleware,

--- a/services/silo-api/src/middleware/auth.rs
+++ b/services/silo-api/src/middleware/auth.rs
@@ -50,8 +50,8 @@ pub async fn auth_middleware(
         tracing::error!("Could not get user from database in middleware {e}");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
-    // Pass the user to the extensions
-    tracing::trace!("Inserting user into request");
+    // Pass the user (including settings) to the extensions
+    tracing::trace!("Inserting user with settings into request");
     req.extensions_mut().insert(Some(user));
     tracing::trace!("Passing to next task");
     Ok(next.run(req).await)


### PR DESCRIPTION
Adds a settings page with a few example settings, as well as being able to store those settings in the backend.

This is a setup for saving chat messages for a streamer. When a streamer enables these settings, we'll use them as a trigger to subscribe to the relative events in Twitch's Event Sub