### PR TITLE
Migrate database on Deployments

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -12,8 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
       - uses: Swatinem/rust-cache@v2
-      - run: rustup toolchain install stable --profile minimal
       - uses: extractions/setup-just@v2
       - name: build
         run: just build-api

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: moonrepo/setup-rust@v1
+        with:
+          cache-base: main
       - uses: Swatinem/rust-cache@v2
       - uses: extractions/setup-just@v2
       - name: build

--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -12,8 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
       - uses: Swatinem/rust-cache@v2
-      - run: rustup toolchain install stable --profile minimal
       - uses: extractions/setup-just@v2
       - name: build
         run: just build-queue

--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: moonrepo/setup-rust@v1
+        with:
+          cache-base: main
       - uses: Swatinem/rust-cache@v2
       - uses: extractions/setup-just@v2
       - name: build

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - uses: moonrepo/setup-rust@v1
+        with:
+          cache-base: main
       - uses: Swatinem/rust-cache@v2
       - uses: extractions/setup-just@v2
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: extractions/setup-just@v2
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
@@ -26,6 +29,12 @@ jobs:
 
       - name: Save DigitalOcean kubeconfig
         run: doctl kubernetes cluster kubeconfig save ${{ vars.CLUSTER_NAME }}
+
+      - name: Install SQLX
+        run: cargo install sqlx-cli
+
+      - name: Run SQLX migrations
+        run: just migrate
 
       - name: Update kustomization
         run: |

--- a/justfile
+++ b/justfile
@@ -45,10 +45,10 @@ build-web:
     yarn build
 
 build-api:
-    cargo build -p api --release
+    cargo build -p api
 
 build-queue:
-    cargo build -p forge --release
+    cargo build -p forge
 
 # Docker build commands - Queue Service (forge-queue)
 biq: build-image-queue  # Shorthand for building queue image

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.84.1"


### PR DESCRIPTION
This updates the CI to run new database migrations when we deploy to staging. Additionally, I fixed how rust was being installed which should cache now, making it a bit faster.